### PR TITLE
Change default ec algorithm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@payid-org/utils",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -663,6 +663,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -765,26 +766,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "beautify-json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/beautify-json/-/beautify-json-1.0.1.tgz",
-      "integrity": "sha512-nyG8AHxiH3VzmZp2c1tFklykD2fnaBz0sA9Kp/VsaMG84NbsQpzQrGTR0Etmqlt3HyK7RYp6jEFgI+9Unt23qA==",
-      "requires": {
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
-      }
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -973,6 +954,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -980,7 +962,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "comment-parser": {
       "version": "0.7.5",
@@ -1201,7 +1184,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "7.5.0",
@@ -1879,7 +1863,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -3384,6 +3369,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@payid-org/utils",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@payid-org/utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payid-org/utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A TypeScript library providing PayID utility functions",
   "homepage": "https://github.com/payid-org/utils#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payid-org/utils",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A TypeScript library providing PayID utility functions",
   "homepage": "https://github.com/payid-org/utils#readme",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@payid-org/utils",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "description": "A TypeScript library providing PayID utility functions",
   "homepage": "https://github.com/payid-org/utils#readme",
   "bugs": {
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
-    "beautify-json": "^1.0.1",
     "jose": "^1.27.3"
   },
   "devDependencies": {

--- a/src/verifiable/keys.ts
+++ b/src/verifiable/keys.ts
@@ -92,7 +92,7 @@ export function getDefaultAlgorithm(
   jwk: JWKRSAKey | JWKECKey | JWKOctKey | JWKOKPKey,
 ): string {
   if (jwk.kty === 'EC') {
-    return 'ES256K'
+    return 'ES256'
   }
   if (jwk.kty === 'oct') {
     return 'HS512'

--- a/test/unit/verifiable/signatures.test.ts
+++ b/test/unit/verifiable/signatures.test.ts
@@ -111,8 +111,14 @@ describe('sign()', function () {
 }`
     assert.isTrue(verifyPayId(json))
   })
-})
 
-function defaultAlgorithm(key: JWK.ECKey): string {
-  return getDefaultAlgorithm(key.toJWK())
-}
+  /**
+   * Gets the default algorithm for a ECKey.
+   *
+   * @param key - The key.
+   * @returns The default algorithm to use.
+   */
+  function defaultAlgorithm(key: JWK.ECKey): string {
+    return getDefaultAlgorithm(key.toJWK())
+  }
+})


### PR DESCRIPTION
## High Level Overview of Change

Change default curve and algorithm to P-256 / ES256 because secp256k1 / ES256k does not have wide support by JWS libraries.

### Context of Change

Per jwt.io, ES256k is not supported by the majority of JWT libraries, and none for .Net, Go, Rust, and browser-based JS libraries.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release




